### PR TITLE
C++11 overhaul - Fixes #7, fixes #9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8)
 project(Libiqxmlrpc)
 set(Libiqxmlrpc_VERSION 0.13.6)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(libiqxmlrpc)
 
 option(build_tests "Build tests?" OFF)

--- a/doc/libiqxmlrpc.doxygen.in
+++ b/doc/libiqxmlrpc.doxygen.in
@@ -472,12 +472,6 @@ HTML_FOOTER            =
 
 HTML_STYLESHEET        = 
 
-# If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes, 
-# files or namespaces will be aligned in HTML using tables. If set to 
-# NO a bullet list will be used.
-
-HTML_ALIGN_MEMBERS     = NO
-
 # If the GENERATE_HTMLHELP tag is set to YES, additional index files 
 # will be generated that can be used as input for tools like the 
 # Microsoft HTML help workshop to generate a compressed HTML help file (.chm) 

--- a/libiqxmlrpc/api_export.h
+++ b/libiqxmlrpc/api_export.h
@@ -6,9 +6,9 @@
 
 #include "sysinc.h"
 
-#if defined(WIN32) || defined(__MINGW32__)
+#if defined(_WIN32) || defined(__MINGW32__)
   #define LIBIQXMLRPC_DLL
-#endif // WIN32 || __MINGW32__
+#endif // _WIN32 || __MINGW32__
 
 #ifdef LIBIQXMLRPC_DLL
   #if defined(LIBIQXMLRPC_COMPILATION) && defined(DLL_EXPORT)

--- a/libiqxmlrpc/client.cc
+++ b/libiqxmlrpc/client.cc
@@ -5,6 +5,8 @@
 #include "client_conn.h"
 #include "client_opts.h"
 
+#include <memory>
+
 namespace iqxmlrpc {
 
 //
@@ -21,14 +23,14 @@ public:
     opts(addr, uri, vhost) {}
 
   Client_options opts;
-  boost::scoped_ptr<Client_connection> conn_cache;
+  std::unique_ptr<Client_connection> conn_cache;
 };
 
 //
 // Auto_conn
 //
 
-class Auto_conn: boost::noncopyable {
+class Auto_conn {
 public:
   Auto_conn( Client_base::Impl& client_impl, Client_base& client ):
     client_impl_(client_impl)
@@ -45,6 +47,10 @@ public:
       conn_ptr_ = tmp_conn_.get();
     }
   }
+  Auto_conn(const Auto_conn&) = delete;
+  Auto_conn(Auto_conn&&) = delete;
+  Auto_conn& operator=(const Auto_conn&) = delete;
+  Auto_conn& operator=(Auto_conn&&) = delete;
 
   ~Auto_conn()
   {
@@ -74,7 +80,7 @@ private:
   }
 
   Client_base::Impl& client_impl_;
-  boost::scoped_ptr<Client_connection> tmp_conn_;
+  std::unique_ptr<Client_connection> tmp_conn_;
   Client_connection* conn_ptr_;
 };
 

--- a/libiqxmlrpc/client.h
+++ b/libiqxmlrpc/client.h
@@ -9,7 +9,8 @@
 #include "response.h"
 
 #include <boost/optional.hpp>
-#include <boost/scoped_ptr.hpp>
+
+#include <memory>
 
 namespace iqxmlrpc {
 
@@ -22,13 +23,17 @@ class Client_connection;
 
 //! Client base class.
 //! It is responsible for performing RPC calls and connection management.
-class LIBIQXMLRPC_API Client_base: boost::noncopyable {
+class LIBIQXMLRPC_API Client_base {
 public:
   Client_base(
     const iqnet::Inet_addr& addr,
     const std::string& uri,
     const std::string& vhost
   );
+  Client_base(const Client_base&) = delete;
+  Client_base(Client_base&&) = delete;
+  Client_base& operator=(const Client_base&) = delete;
+  Client_base& operator=(Client_base&&) = delete;
 
   virtual ~Client_base();
 
@@ -69,7 +74,7 @@ private:
   friend class Auto_conn;
   class Impl;
 
-  boost::scoped_ptr<Impl> impl_;
+  std::unique_ptr<Impl> impl_;
 };
 
 #ifdef _MSC_VER

--- a/libiqxmlrpc/client_conn.cc
+++ b/libiqxmlrpc/client_conn.cc
@@ -5,6 +5,8 @@
 #include "client_opts.h"
 #include "http.h"
 
+#include <memory>
+
 namespace iqxmlrpc {
 
 Client_connection::Client_connection():
@@ -22,7 +24,7 @@ Response Client_connection::process_session( const Request& req, const XHeaders&
 
   std::string req_xml_str( dump_request(req) );
 
-  std::auto_ptr<Request_header> req_h(
+  std::unique_ptr<Request_header> req_h(
     new Request_header(
       decorate_uri(),
       opts().vhost(),
@@ -38,7 +40,7 @@ Response Client_connection::process_session( const Request& req, const XHeaders&
   req_p.set_keep_alive( opts().keep_alive() );
 
   // Received packet
-  std::auto_ptr<Packet> res_p( do_process_session(req_p.dump()) );
+  std::unique_ptr<Packet> res_p( do_process_session(req_p.dump()) );
 
   const Response_header* res_h =
     static_cast<const Response_header*>(res_p->header());

--- a/libiqxmlrpc/connector.cc
+++ b/libiqxmlrpc/connector.cc
@@ -6,7 +6,7 @@
 
 namespace iqnet {
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #define IQXMLRPC_INPROGRESS WSAEWOULDBLOCK
 #else
 #define IQXMLRPC_INPROGRESS EINPROGRESS

--- a/libiqxmlrpc/dispatcher_manager.h
+++ b/libiqxmlrpc/dispatcher_manager.h
@@ -6,8 +6,6 @@
 
 #include "method.h"
 
-#include <boost/noncopyable.hpp>
-
 namespace iqxmlrpc {
 
 #ifdef _MSC_VER
@@ -20,12 +18,16 @@ namespace iqxmlrpc {
  *  register_method operation and optionally system one, which holds
  *  server's built-in methods
  */
-class LIBIQXMLRPC_API Method_dispatcher_manager: boost::noncopyable {
+class LIBIQXMLRPC_API Method_dispatcher_manager {
   class Impl;
   Impl* impl_;
 
 public:
   Method_dispatcher_manager();
+  Method_dispatcher_manager(const Method_dispatcher_manager&) = delete;
+  Method_dispatcher_manager(Method_dispatcher_manager&&) = delete;
+  Method_dispatcher_manager& operator=(const Method_dispatcher_manager&) = delete;
+  Method_dispatcher_manager& operator=(Method_dispatcher_manager&&) = delete;
   ~Method_dispatcher_manager();
 
   //! Registers method factory in default method dispatcher.

--- a/libiqxmlrpc/executor.h
+++ b/libiqxmlrpc/executor.h
@@ -12,9 +12,10 @@
 #pragma warning(disable: 4275)
 #endif
 
-#include <boost/thread/thread.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
+#include <boost/thread/thread.hpp> // thread_group
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -46,7 +47,7 @@ struct Serial_executor_traits
 struct Pool_executor_traits
 {
   typedef Pool_executor_factory Executor_factory;
-  typedef boost::mutex Lock;
+  typedef std::mutex Lock;
 };
 
 //! Abstract executor class. Defines the policy for method execution.
@@ -134,11 +135,11 @@ class LIBIQXMLRPC_API Pool_executor_factory: public Executor_factory_base {
 
   // Objects Pool_thread works with
   std::deque<Pool_executor*> req_queue;
-  boost::mutex               req_queue_lock;
-  boost::condition           req_queue_cond;
+  std::mutex               req_queue_lock;
+  std::condition_variable  req_queue_cond;
 
   bool          in_destructor;
-  boost::mutex  destructor_lock;
+  std::mutex    destructor_lock;
 
 public:
   Pool_executor_factory(unsigned num_threads);

--- a/libiqxmlrpc/http.cc
+++ b/libiqxmlrpc/http.cc
@@ -312,7 +312,7 @@ void Request_header::get_authinfo(std::string& user, std::string& pw) const
   if (v[0] != "basic")
     throw Unauthorized();
 
-  boost::scoped_ptr<Binary_data> bin_authinfo( Binary_data::from_base64(v[1]) );
+  std::unique_ptr<Binary_data> bin_authinfo( Binary_data::from_base64(v[1]) );
   std::string data = bin_authinfo->get_data();
 
   size_t colon_it = data.find_first_of(":");
@@ -324,7 +324,7 @@ void Request_header::get_authinfo(std::string& user, std::string& pw) const
 void Request_header::set_authinfo(const std::string& u, const std::string& p)
 {
   std::string h = u + ":" + p;
-  boost::scoped_ptr<Binary_data> bin_authinfo( Binary_data::from_data(h) );
+  std::unique_ptr<Binary_data> bin_authinfo( Binary_data::from_data(h) );
   set_option( names::authorization, "Basic " + bin_authinfo->get_base64() );
 }
 

--- a/libiqxmlrpc/http.h
+++ b/libiqxmlrpc/http.h
@@ -9,9 +9,9 @@
 #include "xheaders.h"
 
 #include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <map>
+#include <memory>
 #include <string>
 
 namespace iqxmlrpc {
@@ -149,7 +149,7 @@ private:
 //! HTTP packet: Header + Content.
 class LIBIQXMLRPC_API Packet {
 protected:
-  boost::shared_ptr<http::Header> header_;
+  std::shared_ptr<http::Header> header_;
   std::string content_;
 
 public:

--- a/libiqxmlrpc/http_client.h
+++ b/libiqxmlrpc/http_client.h
@@ -9,6 +9,8 @@
 #include "connector.h"
 #include "reactor.h"
 
+#include <memory>
+
 namespace iqxmlrpc
 {
 
@@ -19,7 +21,7 @@ class LIBIQXMLRPC_API Http_client_connection:
   public iqxmlrpc::Client_connection,
   public iqnet::Connection
 {
-  std::auto_ptr<iqnet::Reactor_base> reactor;
+  std::unique_ptr<iqnet::Reactor_base> reactor;
   std::string out_str;
   http::Packet* resp_packet;
 

--- a/libiqxmlrpc/https_client.cc
+++ b/libiqxmlrpc/https_client.cc
@@ -8,6 +8,8 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <memory>
+
 using namespace iqnet;
 
 namespace iqxmlrpc {
@@ -45,7 +47,7 @@ Https_proxy_client_connection::Https_proxy_client_connection(
   Client_connection(),
   Connection( s ),
   reactor( new Reactor<Null_lock> ),
-  resp_packet(0),
+  resp_packet(nullptr),
   non_blocking(nb)
 {
   sock.set_non_blocking( nb );

--- a/libiqxmlrpc/https_client.h
+++ b/libiqxmlrpc/https_client.h
@@ -10,7 +10,7 @@
 #include "reactor.h"
 #include "ssl_connection.h"
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 namespace iqxmlrpc
 {
@@ -32,8 +32,8 @@ protected:
 
   void setup_tunnel();
 
-  boost::scoped_ptr<iqnet::Reactor_base> reactor;
-  boost::scoped_ptr<http::Packet> resp_packet;
+  std::unique_ptr<iqnet::Reactor_base> reactor;
+  std::unique_ptr<http::Packet> resp_packet;
   bool non_blocking;
   std::string out_str;
 };
@@ -43,7 +43,7 @@ class LIBIQXMLRPC_API Https_client_connection:
   public iqxmlrpc::Client_connection,
   public iqnet::ssl::Reaction_connection
 {
-  std::auto_ptr<iqnet::Reactor_base> reactor;
+  std::unique_ptr<iqnet::Reactor_base> reactor;
   http::Packet* resp_packet;
   std::string out_str;
   bool established;

--- a/libiqxmlrpc/inet_addr.cc
+++ b/libiqxmlrpc/inet_addr.cc
@@ -17,7 +17,7 @@ std::string get_host_name()
 }
 
 
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__)
 #define IQXMLRPC_GETHOSTBYNAME(_h) \
   hent = ::gethostbyname( _h ); \
   if( !hent ) { \

--- a/libiqxmlrpc/inet_addr.h
+++ b/libiqxmlrpc/inet_addr.h
@@ -10,8 +10,8 @@
 
 #include "api_export.h"
 
+#include <memory>
 #include <string>
-#include <boost/shared_ptr.hpp>
 
 //! Object-oriented networking/multithreading infrastructure.
 namespace iqnet
@@ -28,7 +28,7 @@ std::string LIBIQXMLRPC_API get_host_name();
 /*! A wrapper for sockaddr_in system structure. */
 class LIBIQXMLRPC_API Inet_addr {
   struct Impl;
-  boost::shared_ptr<Impl> impl_;
+  std::shared_ptr<Impl> impl_;
 
 public:
   //! Does nothing.

--- a/libiqxmlrpc/method.h
+++ b/libiqxmlrpc/method.h
@@ -10,9 +10,9 @@
 #include "xheaders.h"
 
 #include <boost/utility.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <map>
+#include <memory>
 #include <string>
 
 namespace iqxmlrpc
@@ -100,8 +100,14 @@ private:
  *  in the same time. So the synchronization of internal state of
  *  user-defined interceptor is up to it's creator.
  */
-class LIBIQXMLRPC_API Interceptor: boost::noncopyable {
+class LIBIQXMLRPC_API Interceptor {
 public:
+  Interceptor() = default;
+
+  Interceptor(const Interceptor&) = delete;
+  Interceptor(Interceptor&&) = delete;
+  Interceptor& operator=(const Interceptor&) = delete;
+  Interceptor& operator=(Interceptor&&) = delete;
   virtual ~Interceptor() {}
 
   void nest(Interceptor* ic)
@@ -127,7 +133,7 @@ protected:
   }
 
 private:
-  boost::scoped_ptr<Interceptor> nested;
+  std::unique_ptr<Interceptor> nested;
 };
 
 #ifdef _MSC_VER

--- a/libiqxmlrpc/net_except.cc
+++ b/libiqxmlrpc/net_except.cc
@@ -25,9 +25,9 @@ exception_message(const std::string& prefix, bool use_errno, int myerrno)
 
     myerrno = myerrno ? myerrno : errno;
 
-#if !defined WIN32 && defined _GNU_SOURCE
+#if !defined _WIN32 && defined _GNU_SOURCE
     b = strerror_r( myerrno, buf, sizeof(buf) - 1 );
-#elif !defined WIN32
+#elif !defined _WIN32
     strerror_r( myerrno, buf, sizeof(buf) - 1 );
 #else
     strerror_s( buf, sizeof(buf) - 1, WSAGetLastError() );

--- a/libiqxmlrpc/parser2.h
+++ b/libiqxmlrpc/parser2.h
@@ -5,9 +5,9 @@
 #define _iqxmlrpc_parser2_h_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 namespace iqxmlrpc {
 
@@ -93,7 +93,7 @@ public:
 
 private:
   class Impl;
-  boost::shared_ptr<Impl> impl_;
+  std::shared_ptr<Impl> impl_;
 };
 
 class StateMachine {

--- a/libiqxmlrpc/reactor_interrupter.h
+++ b/libiqxmlrpc/reactor_interrupter.h
@@ -6,8 +6,6 @@
 
 #include "reactor.h"
 
-#include <boost/utility.hpp>
-
 namespace iqnet {
 
 #ifdef _MSC_VER
@@ -15,9 +13,13 @@ namespace iqnet {
 #pragma warning(disable: 4275)
 #endif
 
-class LIBIQXMLRPC_API Reactor_interrupter: boost::noncopyable {
+class LIBIQXMLRPC_API Reactor_interrupter {
 public:
   Reactor_interrupter(Reactor_base*);
+  Reactor_interrupter(const Reactor_interrupter&) = delete;
+  Reactor_interrupter(Reactor_interrupter&&) = delete;
+  Reactor_interrupter& operator=(const Reactor_interrupter&) = delete;
+  Reactor_interrupter& operator=(Reactor_interrupter&&) = delete;
   ~Reactor_interrupter();
 
   void make_interrupt();

--- a/libiqxmlrpc/reactor_poll_impl.h
+++ b/libiqxmlrpc/reactor_poll_impl.h
@@ -7,18 +7,20 @@
 #ifdef HAVE_POLL
 #include "reactor.h"
 
-#include <boost/utility.hpp>
-
 namespace iqnet
 {
 
 //! Reactor implementation helper based on poll() system call.
-class LIBIQXMLRPC_API Reactor_poll_impl: boost::noncopyable {
+class LIBIQXMLRPC_API Reactor_poll_impl {
   struct Impl;
   Impl* impl;
 
 public:
   Reactor_poll_impl();
+  Reactor_poll_impl(const Reactor_poll_impl&) = delete;
+  Reactor_poll_impl(Reactor_poll_impl&&) = delete;
+  Reactor_poll_impl& operator=(const Reactor_poll_impl&) = delete;
+  Reactor_poll_impl& operator=(Reactor_poll_impl&&) = delete;
   virtual ~Reactor_poll_impl();
 
   void reset(const Reactor_base::HandlerStateList&);

--- a/libiqxmlrpc/reactor_select_impl.h
+++ b/libiqxmlrpc/reactor_select_impl.h
@@ -7,8 +7,6 @@
 #ifndef HAVE_POLL
 #include "reactor.h"
 
-#include <boost/utility.hpp>
-
 namespace iqnet
 {
 
@@ -19,13 +17,17 @@ namespace iqnet
 #endif
 
 //! Reactor implementation helper based on select() system call.
-class LIBIQXMLRPC_API Reactor_select_impl: boost::noncopyable {
+class LIBIQXMLRPC_API Reactor_select_impl {
   Socket::Handler max_fd;
   fd_set read_set, write_set, err_set;
   Reactor_base::HandlerStateList hs;
 
 public:
   Reactor_select_impl();
+  Reactor_select_impl(const Reactor_select_impl&) = delete;
+  Reactor_select_impl(Reactor_select_impl&&) = delete;
+  Reactor_select_impl& operator=(const Reactor_select_impl&) = delete;
+  Reactor_select_impl& operator=(Reactor_select_impl&&) = delete;
   virtual ~Reactor_select_impl();
 
   void reset(const Reactor_base::HandlerStateList&);

--- a/libiqxmlrpc/response.h
+++ b/libiqxmlrpc/response.h
@@ -4,7 +4,7 @@
 #ifndef _iqxmlrpc_response_h_
 #define _iqxmlrpc_response_h_
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 #include "api_export.h"
 
@@ -41,7 +41,7 @@ public:
   const std::string& fault_string() const { return fault_string_; }
 
 private:
-  boost::shared_ptr<Value> value_;
+  std::shared_ptr<Value> value_;
   int fault_code_;
   std::string fault_string_;
 };

--- a/libiqxmlrpc/server.h
+++ b/libiqxmlrpc/server.h
@@ -31,12 +31,17 @@ class Auth_Plugin_base;
 #endif
 
 //! XML-RPC server.
-class LIBIQXMLRPC_API Server: boost::noncopyable {
+class LIBIQXMLRPC_API Server {
 public:
   Server(
     const iqnet::Inet_addr& addr,
     iqnet::Accepted_conn_factory* conn_factory,
     Executor_factory_base* executor_factory );
+
+  Server(const Server&) = delete;
+  Server(Server&&) = delete;
+  Server& operator=(const Server&) = delete;
+  Server& operator=(Server&&) = delete;
 
   virtual ~Server();
 

--- a/libiqxmlrpc/server_conn.cc
+++ b/libiqxmlrpc/server_conn.cc
@@ -6,6 +6,8 @@
 #include "http_errors.h"
 #include "server.h"
 
+#include <memory>
+
 using namespace iqxmlrpc;
 
 Server_connection::Server_connection( const iqnet::Inet_addr& a ):
@@ -50,7 +52,7 @@ http::Packet* Server_connection::read_request( const std::string& s )
 
 void Server_connection::schedule_response( http::Packet* pkt )
 {
-  std::auto_ptr<http::Packet> p(pkt);
+  std::unique_ptr<http::Packet> p(pkt);
   p->set_keep_alive( keep_alive );
   response = p->dump();
   do_schedule_response();

--- a/libiqxmlrpc/socket.cc
+++ b/libiqxmlrpc/socket.cc
@@ -17,12 +17,12 @@ Socket::Socket()
   if( (sock = socket( PF_INET, SOCK_STREAM, IPPROTO_TCP )) == -1 )
     throw network_error( "Socket::Socket" );
 
-#ifndef WIN32
+#ifndef _WIN32
   {
   int enable = 1;
   setsockopt( sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable) );
   }
-#endif //WIN32
+#endif //_WIN32
 
 #if defined(__APPLE__)
   {
@@ -45,16 +45,16 @@ void Socket::shutdown()
 
 void Socket::close()
 {
-#ifdef WIN32
+#ifdef _WIN32
   closesocket(sock);
 #else
   ::close( sock );
-#endif //WIN32
+#endif //_WIN32
 }
 
 void Socket::set_non_blocking( bool flag )
 {
-#ifdef WIN32
+#ifdef _WIN32
   unsigned long f = flag ? 1 : 0;
   if( ioctlsocket(sock, FIONBIO, &f) != 0 )
     throw network_error( "Socket::set_non_blocking");
@@ -64,7 +64,7 @@ void Socket::set_non_blocking( bool flag )
 
   if( fcntl( sock, F_SETFL, O_NDELAY ) == -1 )
     throw network_error( "Socket::set_non_blocking" );
-#endif //WIN32
+#endif //_WIN32
 }
 
 #if defined(MSG_NOSIGNAL)
@@ -135,7 +135,7 @@ bool Socket::connect( const iqnet::Inet_addr& peer_addr )
   bool wouldblock = false;
 
   if( code == -1 ) {
-#ifndef WIN32
+#ifndef _WIN32
     wouldblock = errno == EINPROGRESS;
 #else
     wouldblock = get_last_error() == WSAEWOULDBLOCK;
@@ -163,7 +163,7 @@ Inet_addr Socket::get_addr() const
 int Socket::get_last_error()
 {
   int err = 0;
-#ifndef WIN32
+#ifndef _WIN32
   socklen_t int_sz = sizeof(err);
   ::getsockopt( sock, SOL_SOCKET, SO_ERROR, &err, &int_sz );
 #else

--- a/libiqxmlrpc/ssl_lib.cc
+++ b/libiqxmlrpc/ssl_lib.cc
@@ -1,7 +1,7 @@
 //  Libiqxmlrpc - an object-oriented XML-RPC solution.
 //  Copyright (C) 2011 Anton Dedov
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #endif
 
@@ -12,11 +12,10 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-#include <boost/noncopyable.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/thread/once.hpp>
+#include <mutex>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <pthread.h>
 #endif
 
@@ -31,18 +30,22 @@ namespace ssl {
 // Mutli-threading support stuff
 //
 
-class LockContainer: boost::noncopyable {
+class LockContainer {
 public:
   LockContainer():
     size(CRYPTO_num_locks()),
-    locks(new boost::mutex[size])
+    locks(new std::mutex[size])
   {
   }
+  LockContainer(const LockContainer&) = delete;
+  LockContainer(LockContainer&&) = delete;
+  LockContainer& operator=(const LockContainer&) = delete;
+  LockContainer& operator=(LockContainer&&) = delete;
 
   ~LockContainer();
 
   size_t size;
-  boost::mutex* locks;
+  std::mutex* locks;
 };
 
 void
@@ -51,7 +54,7 @@ openssl_lock_callback(int mode, int n, const char* /*file*/, int /*line*/)
   static LockContainer lks;
   // assert n < lks.size
 
-  boost::mutex& m = lks.locks[n];
+  std::mutex& m = lks.locks[n];
   if (mode & CRYPTO_LOCK) {
     m.lock();
   } else {

--- a/libiqxmlrpc/ssl_lib.h
+++ b/libiqxmlrpc/ssl_lib.h
@@ -7,8 +7,8 @@
 #include "api_export.h"
 
 #include <openssl/ssl.h>
-#include <boost/shared_ptr.hpp>
 #include <stdexcept>
+#include <memory>
 
 namespace iqnet {
 namespace ssl {
@@ -65,7 +65,7 @@ private:
   Ctx();
 
   struct Impl;
-  boost::shared_ptr<Impl> impl_;
+  std::shared_ptr<Impl> impl_;
 };
 
 #ifdef _MSC_VER

--- a/libiqxmlrpc/sysinc.h
+++ b/libiqxmlrpc/sysinc.h
@@ -9,7 +9,7 @@
 #ifndef _iqxmlrpc_sysinc_h_
 #define _iqxmlrpc_sysinc_h_
 
-#ifdef WIN32
+#ifdef _WIN32
   #define BOOST_ALL_NO_LIB
 
 #if _MSC_VER < 1700
@@ -28,7 +28,7 @@
   #include <arpa/inet.h>
   #include <netinet/in.h>
   #include <netinet/tcp.h>
-#endif //WIN32
+#endif //_WIN32
 
 #include <ctype.h>
 #include <locale.h>

--- a/libiqxmlrpc/util.h
+++ b/libiqxmlrpc/util.h
@@ -66,13 +66,18 @@ public:
 
 //! Provides serialized access to some bool value
 template <class Lock>
-class LockedBool: boost::noncopyable {
+class LockedBool {
   bool val;
   Lock lock;
 
 public:
   LockedBool(bool default_):
     val(default_) {}
+
+  LockedBool(const LockedBool&) = delete;
+  LockedBool(LockedBool&&) = delete;
+  LockedBool& operator=(const LockedBool&) = delete;
+  LockedBool& operator=(LockedBool&&) = delete;
 
   ~LockedBool() {}
 

--- a/libiqxmlrpc/value_parser.cc
+++ b/libiqxmlrpc/value_parser.cc
@@ -6,6 +6,8 @@
 #include "except.h"
 #include "value_parser.h"
 
+#include <memory>
+
 namespace iqxmlrpc {
 
 ValueBuilderBase::ValueBuilderBase(Parser& parser, bool expect_text):
@@ -188,8 +190,8 @@ ValueBuilder::do_visit_element_end(const std::string&)
   if (retval.get())
     return;
 
-  std::auto_ptr<Int> default_int(Value::get_default_int());
-  std::auto_ptr<Int64> default_int64(Value::get_default_int64());
+  std::unique_ptr<Int> default_int(Value::get_default_int());
+  std::unique_ptr<Int64> default_int64(Value::get_default_int64());
 
   switch (state_.get_state()) {
   case VALUE:

--- a/libiqxmlrpc/value_parser.h
+++ b/libiqxmlrpc/value_parser.h
@@ -7,6 +7,8 @@
 #include "parser2.h"
 #include "value.h"
 
+#include <memory>
+
 namespace iqxmlrpc {
 
 class ValueBuilderBase: public BuilderBase {
@@ -20,7 +22,7 @@ public:
   }
 
 protected:
-  std::auto_ptr<Value_type> retval;
+  std::unique_ptr<Value_type> retval;
 };
 
 class ValueBuilder: public ValueBuilderBase {

--- a/libiqxmlrpc/xml_builder.h
+++ b/libiqxmlrpc/xml_builder.h
@@ -6,13 +6,12 @@
 
 #include "api_export.h"
 
-#include <boost/utility.hpp>
 #include <string>
 #include <libxml/xmlwriter.h>
 
 namespace iqxmlrpc {
 
-class XmlBuilder: boost::noncopyable {
+class XmlBuilder {
 public:
   class Node {
   public:
@@ -27,6 +26,10 @@ public:
   };
 
   XmlBuilder();
+  XmlBuilder(const XmlBuilder&) = delete;
+  XmlBuilder(XmlBuilder&&) = delete;
+  XmlBuilder& operator=(const XmlBuilder&) = delete;
+  XmlBuilder& operator=(XmlBuilder&&) = delete;
   ~XmlBuilder();
 
   void
@@ -35,8 +38,7 @@ public:
   void
   stop();
 
-  std::string
-  content() const;
+  std::string content() const;
 
 private:
   xmlBufferPtr buf;

--- a/tests/client.cc
+++ b/tests/client.cc
@@ -11,9 +11,11 @@
 #include "client_common.h"
 #include "client_opts.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <winsock2.h>
 #endif
+
+#include <memory>
 
 using namespace boost::unit_test;
 using namespace iqxmlrpc;
@@ -26,7 +28,7 @@ class ClientFixture {
 public:
   ClientFixture()
   {
-#if defined(WIN32)
+#if defined(_WIN32)
     WORD wVersionRequested;
     WSADATA wsaData;
     wVersionRequested = MAKEWORD(2, 2);
@@ -115,7 +117,7 @@ BOOST_AUTO_TEST_CASE( get_file_test )
 
   MD5(reinterpret_cast<md5char*>(d.get_data().data()),
     d.get_data().length(), md5);
-  std::auto_ptr<Binary_data> gen_md5( Binary_data::from_data(
+  std::unique_ptr<Binary_data> gen_md5( Binary_data::from_data(
     reinterpret_cast<strchar*>(md5), sizeof(md5)) );
 
   BOOST_TEST_MESSAGE("Recieved MD5:   " + m.get_base64());

--- a/tests/client_stress.cc
+++ b/tests/client_stress.cc
@@ -1,9 +1,5 @@
 #define BOOST_TEST_MODULE test_client_stress
-#include <stdlib.h>
 #include <openssl/md5.h>
-#include <memory>
-#include <iostream>
-#include <sstream>
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/thread/thread.hpp>
@@ -11,9 +7,15 @@
 #include "client_common.h"
 #include "client_opts.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <winsock2.h>
 #endif
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <thread>
 
 using namespace boost::unit_test;
 using namespace boost::program_options;
@@ -45,7 +47,7 @@ class ClientFixture {
 public:
   ClientFixture()
   {
-#if defined(WIN32)
+#if defined(_WIN32)
     WORD wVersionRequested;
     WSADATA wsaData;
     wVersionRequested = MAKEWORD(2, 2);
@@ -84,7 +86,7 @@ void do_call(Client_base* client)
 void do_test()
 {
   try {
-    std::auto_ptr<Client_base> client(test_config.create_instance());
+    std::unique_ptr<Client_base> client(test_config.create_instance());
     for (int i = 0; i < test_config.calls_per_thread(); ++i) {
       do_call(client.get());
     }

--- a/tests/parser2.cc
+++ b/tests/parser2.cc
@@ -1,13 +1,15 @@
 #define BOOST_TEST_MODULE test_parser
-#include <iostream>
-#include <vector>
-#include <algorithm>
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test.hpp>
 #include "libiqxmlrpc/value.h"
 #include "libiqxmlrpc/value_parser.h"
 #include "libiqxmlrpc/request_parser.h"
 #include "libiqxmlrpc/response_parser.h"
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <vector>
 
 using namespace boost::unit_test;
 using namespace iqxmlrpc;
@@ -259,7 +261,7 @@ BOOST_AUTO_TEST_CASE(test_parse_request)
   </params> \
 </methodCall>";
 
-  std::auto_ptr<Request> req(parse_request(r));
+  std::unique_ptr<Request> req(parse_request(r));
   BOOST_CHECK_EQUAL(req->get_name(), "get_weather");
   BOOST_CHECK_EQUAL(req->get_params().size(), 2);
   BOOST_CHECK_EQUAL(req->get_params().front().get_string(), "Krasnoyarsk");
@@ -278,7 +280,7 @@ BOOST_AUTO_TEST_CASE(test_parse_request_empty_param)
   </params> \
 </methodCall>";
 
-  std::auto_ptr<Request> req(parse_request(r));
+  std::unique_ptr<Request> req(parse_request(r));
   BOOST_CHECK_EQUAL(req->get_name(), "do_something");
   BOOST_CHECK_EQUAL(req->get_params().size(), 1);
   BOOST_CHECK_EQUAL(req->get_params().back().get_string(), "");
@@ -287,7 +289,7 @@ BOOST_AUTO_TEST_CASE(test_parse_request_empty_param)
 BOOST_AUTO_TEST_CASE(test_parse_request_no_params)
 {
   std::string r = "<methodCall><methodName>do_something</methodName></methodCall>";
-  std::auto_ptr<Request> req(parse_request(r));
+  std::unique_ptr<Request> req(parse_request(r));
   BOOST_CHECK_EQUAL(req->get_name(), "do_something");
   BOOST_CHECK_EQUAL(req->get_params().size(), 0);
 }

--- a/tests/test_server.cc
+++ b/tests/test_server.cc
@@ -1,6 +1,3 @@
-#include <signal.h>
-#include <memory>
-#include <iostream>
 #include <boost/utility.hpp>
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test.hpp>
@@ -13,9 +10,13 @@
 #include "methods.h"
 #include "libiqxmlrpc/xheaders.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <winsock2.h>
 #endif
+
+#include <csignal>
+#include <iostream>
+#include <memory>
 
 using namespace boost::unit_test;
 using namespace iqxmlrpc;
@@ -83,13 +84,18 @@ public:
   }
 };
 
-class Test_server: boost::noncopyable {
-  std::auto_ptr<Executor_factory_base> ef_;
-  std::auto_ptr<Server> impl_;
+class Test_server {
+  std::unique_ptr<Executor_factory_base> ef_;
+  std::unique_ptr<Server> impl_;
   PermissiveAuthPlugin auth_plugin_;
 
 public:
   Test_server(const Test_server_config&);
+
+  Test_server(const Test_server&) = delete;
+  Test_server(Test_server&&) = delete;
+  Test_server& operator=(const Test_server&) = delete;
+  Test_server& operator=(Test_server&&) = delete;
 
   Server& impl() { return *impl_.get(); }
 
@@ -99,8 +105,8 @@ public:
 Test_server* test_server = 0;
 
 Test_server::Test_server(const Test_server_config& conf):
-  ef_(0),
-  impl_(0)
+  ef_{nullptr},
+  impl_{nullptr}
 {
   if (conf.numthreads > 1)
   {
@@ -151,7 +157,7 @@ void test_server_sig_handler(int)
 int
 main(int argc, const char** argv)
 {
-#if defined(WIN32)
+#if defined(_WIN32)
   WORD wVersionRequested;
   WSADATA wsaData;
   wVersionRequested = MAKEWORD(2, 2);

--- a/tests/test_value_usage.cc
+++ b/tests/test_value_usage.cc
@@ -1,10 +1,12 @@
 #define BOOST_TEST_MODULE value_test
-#include <iostream>
-#include <vector>
-#include <algorithm>
 #include <boost/test/test_tools.hpp>
 #include <boost/test/unit_test.hpp>
 #include "libiqxmlrpc/value.h"
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <vector>
 
 using namespace boost::unit_test;
 using namespace iqxmlrpc;
@@ -79,7 +81,7 @@ BOOST_AUTO_TEST_CASE( array_test )
     Array a;
     a.push_back(0);
     BOOST_TEST_CHECKPOINT("Suspicious Array cloning");
-    std::auto_ptr<Array> a1(a.clone());
+    std::unique_ptr<Array> a1(a.clone());
     BOOST_CHECK_EQUAL((*a1.get())[0].get_int(), 0);
   }
 
@@ -161,7 +163,7 @@ BOOST_AUTO_TEST_CASE( struct_test )
     BOOST_CHECK(s["pages"].is_int());
 
     BOOST_TEST_CHECKPOINT("Suspicious Struct cloning");
-    std::auto_ptr<Struct> s1(s.clone());
+    std::unique_ptr<Struct> s1(s.clone());
     BOOST_CHECK(s1->has_field("pages"));
   }
 


### PR DESCRIPTION
This is meant as a co-op patch to make the library use and require C++11
or later. This is not a backwards compatible patch since it'll fail to
build in C++ versions prior to C++11.

* TODO: Figure out how to make boost use std::iterator instead of its
  own iterator to get rid of the
  `BOOST_HEADER_DEPRECATED("<iterator>")` warning