### PR TITLE
Fix compilation with boost-1.53 (CentOS 7)

### DIFF
--- a/libiqxmlrpc/ssl_lib.cc
+++ b/libiqxmlrpc/ssl_lib.cc
@@ -12,7 +12,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-#include <boost/core/noncopyable.hpp>
+#include <boost/noncopyable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/once.hpp>
 


### PR DESCRIPTION
This header is deprecated but works with both old and new boost versions
https://github.com/boostorg/core/blob/develop/include/boost/noncopyable.hpp